### PR TITLE
Adding implicit max object size to memcached image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN PKGS='memcached nc' && \
 USER memcached
 
 ENTRYPOINT ["memcached"]
-CMD ["-m", "512", "-vv"]
+CMD ["-m", "512", "-vv", "-I", "2m"]


### PR DESCRIPTION
## Motivation

Add implicit limit for storing data in cache (2mb)